### PR TITLE
Fix for error message appearing on checkout / in logs

### DIFF
--- a/table-rate-shipping-for-woocommerce/mh-wc-table-rate.php
+++ b/table-rate-shipping-for-woocommerce/mh-wc-table-rate.php
@@ -761,7 +761,7 @@ if ( is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
 				/* 
 					Calculate shipping cost. This is called by WooCommerce
 				*/
-				public function calculate_shipping( $package ) {
+				public function calculate_shipping( $package = array() ) {
 				
 					$available_table_rates = $this->get_available_table_rates($package);
 					


### PR DESCRIPTION
Fixes this warning being shown:

[18-Nov-2017 09:01:44 UTC] PHP Warning:  Declaration of
MH_Table_Rate_Shipping_Method::calculate_shipping() should be
compatible with WC_Shipping_Method::calculate_shipping($package =
Array) in
/Applications/MAMP/htdocs/woocommerce/wp-content/plugins/table-rate-ship
ping-for-woocommerce/mh-wc-table-rate.php on line 29